### PR TITLE
Handle OS signals to shutdown gracefully

### DIFF
--- a/server.go
+++ b/server.go
@@ -5,7 +5,9 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"strconv"
+	"syscall"
 	"time"
 
 	"github.com/antage/eventsource"
@@ -34,6 +36,8 @@ var (
 
 func main() {
 	flag.Parse()
+
+	trapSignals()
 
 	defer es.Close()
 
@@ -67,4 +71,15 @@ func updateStream(w http.ResponseWriter, r *http.Request) {
 
 func heartbeatHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
+}
+
+func trapSignals() {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+
+	go func() {
+		sig := <-c
+		log.Printf("Received %s! Exiting...\n", sig)
+		os.Exit(0)
+	}()
 }


### PR DESCRIPTION
I noticed that `foreman` isn't correctly shutting down the eventsource server locally. During shutdown, `foreman` sends a `SIGTERM` to each of its managed processes. Since the eventsource server doesn't respect this, it isn't killed. This leads to the port still being in use when the developer goes to `foreman start` again.